### PR TITLE
Change RxTasks methods to be inlined

### DIFF
--- a/util-firebase/src/main/kotlin/com/tailoredapps/androidutil/firebase/RxTasks.kt
+++ b/util-firebase/src/main/kotlin/com/tailoredapps/androidutil/firebase/RxTasks.kt
@@ -37,21 +37,23 @@ import io.reactivex.SingleEmitter
  * RxTasks.single { GoogleSignIn.getSignedInAccountFromIntent(data) }
  */
 object RxTasks {
-    fun <T> single(taskCreator: () -> Task<T>): Single<T> =
+    inline fun <T> single(crossinline taskCreator: () -> Task<T>): Single<T> =
         Single.create { taskCreator().singleEmitter(it) }
 
-    fun <T> completable(taskCreator: () -> Task<T>): Completable =
+    inline fun <T> completable(crossinline taskCreator: () -> Task<T>): Completable =
         Completable.create { taskCreator().completableEmitter(it) }
 
-    fun <T> maybe(taskCreator: () -> Task<T>): Maybe<T> =
+    inline fun <T> maybe(crossinline taskCreator: () -> Task<T>): Maybe<T> =
         Maybe.create { taskCreator().maybeEmitter(it) }
 
-    private fun <T> Task<T>.singleEmitter(emitter: SingleEmitter<T>) {
+    @PublishedApi
+    internal fun <T> Task<T>.singleEmitter(emitter: SingleEmitter<T>) {
         addOnSuccessListener(emitter::onSuccess)
         addOnFailureListener(emitter::onError)
     }
 
-    private fun <T> Task<T>.maybeEmitter(emitter: MaybeEmitter<T>) {
+    @PublishedApi
+    internal fun <T> Task<T>.maybeEmitter(emitter: MaybeEmitter<T>) {
         addOnSuccessListener {
             if (it == null) emitter.onComplete()
             else emitter.onSuccess(it)
@@ -59,7 +61,8 @@ object RxTasks {
         addOnFailureListener(emitter::onError)
     }
 
-    private fun <T> Task<T>.completableEmitter(emitter: CompletableEmitter) {
+    @PublishedApi
+    internal fun <T> Task<T>.completableEmitter(emitter: CompletableEmitter) {
         addOnSuccessListener { emitter.onComplete() }
         addOnFailureListener(emitter::onError)
     }


### PR DESCRIPTION
The methods of RxTasks are currently not defined as inline, which results in an additional object being created:
```
RxTasks.INSTANCE.single((Function0)(new Function0() {
   // $FF: synthetic method
   // $FF: bridge method
   public Object invoke() {
      return this.invoke();
   }

   @NotNull
   public final Task invoke() {
      FirebaseAnalytics var10000 = FirebaseAnalytics.getInstance(InvokingClass.this.context);
      Intrinsics.checkExpressionValueIsNotNull(var10000, "FirebaseAnalytics.getInstance(context)");
      return var10000.getAppInstanceId();
   }
}));
```
_(decompiled bytecode)_


By making the methods inlined, add the crossinline method to the lambda argument and change the extension functions on `Task` to be internal and a `@PublishedApi`, the methods can be inlined by the compiler resulting in no additional object being created:
```
RxTasks this_$iv = RxTasks.INSTANCE;
int $i$f$single = false;
Intrinsics.checkExpressionValueIsNotNull(Single.create((SingleOnSubscribe)(new InvokingClass$init$$inlined$single$1(this))), "Single.create { taskCreator().singleEmitter(it) }");
```
_(decompiled bytecode)_

This has, however, the side-effect, that the extension functions are (on a bytecode-level) effectively public (which in this use-case should not matter). They are not publicly visible on a Kotlin / programming language level, though. [https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-published-api/index.html](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-published-api/index.html)