### PR TITLE
Add extension functions for RxTasks functionality

### DIFF
--- a/util-firebase/src/main/kotlin/com/tailoredapps/androidutil/firebase/RxTasks.kt
+++ b/util-firebase/src/main/kotlin/com/tailoredapps/androidutil/firebase/RxTasks.kt
@@ -67,3 +67,24 @@ object RxTasks {
         addOnFailureListener(emitter::onError)
     }
 }
+
+fun <T> Task<T>.asSingle(): Single<T> =
+    Single.create { emitter ->
+        addOnSuccessListener(emitter::onSuccess)
+        addOnFailureListener(emitter::onError)
+    }
+
+fun <T> Task<T>.asCompletable(): Completable =
+    Completable.create { emitter ->
+        addOnSuccessListener { emitter.onComplete() }
+        addOnFailureListener(emitter::onError)
+    }
+
+fun <T> Task<T>.asMaybe(): Maybe<T> =
+    Maybe.create { emitter ->
+        addOnSuccessListener {
+            if (it == null) emitter.onComplete()
+            else emitter.onSuccess(it)
+        }
+        addOnFailureListener(emitter::onError)
+    }


### PR DESCRIPTION
I would propose to add the functionality that RxTasks provides as Extension functions.

Currently, the usage of getting e.g. an AutoCompletionPrediction will look something along the lines:

```
RxTasks.single {
    Places.getGeoDataClient(context)
            .getAutocompletePredictions(query, latLngBounds, autocompleteFilter)
}.subscribeOn(Schedulers.io())
```

When providing the functionality as extension functions, this could be refactored to:

```
Places.getGeoDataClient(context)
        .getAutocompletePredictions(query, latLngBounds, autocompleteFilter)
        .asSingle()
        .subscribeOn(Schedulers.io())
```

There is one behavioural change, though, in that the task itself will not be created within the e.g. Single.create context, but beforehand, outside of the rx-chain.

Would like to hear yout thoughts about that.

(The PR currently introduces code duplication, I just wanted to have this place for discussions. Will update the PR once the solution is accepted without code duplication.)