### PR TITLE
Add keyboard state management and extension functions

### DIFF
--- a/util-ui/src/main/kotlin/com/tailoredapps/androidutil/ui/extensions/ViewExt.kt
+++ b/util-ui/src/main/kotlin/com/tailoredapps/androidutil/ui/extensions/ViewExt.kt
@@ -16,29 +16,22 @@
 
 package com.tailoredapps.androidutil.ui.extensions
 
-import android.app.Activity
-import android.content.Context
 import android.view.View
 import android.view.ViewTreeObserver
-import android.view.inputmethod.InputMethodManager
+import com.tailoredapps.androidutil.ui.keyboard.hideKeyboard
+import com.tailoredapps.androidutil.ui.keyboard.showKeyboard
 
 /**
  * Shows the keyboard for a view and focuses it.
  */
-fun <V : View> V.showKeyBoard() {
-    requestFocus()
-    val imm = context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-    imm.showSoftInput(this, InputMethodManager.SHOW_IMPLICIT)
-}
+@Deprecated(message = "Moved to .ui.keyboard.KeyboardExt", replaceWith = ReplaceWith("showKeyboard()"), level = DeprecationLevel.WARNING)
+fun <V : View> V.showKeyBoard() = showKeyboard()
 
 /**
  * Hides the keyboard for a view and unfocuses it.
  */
-fun <V : View> V.hideKeyboard() {
-    val inputMethodManager = context.getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
-    if (inputMethodManager.isActive) inputMethodManager.hideSoftInputFromWindow(windowToken, 0)
-    clearFocus()
-}
+@Deprecated(message = "Moved to .ui.keyboard.KeyboardExt", replaceWith = ReplaceWith("hideKeyboard()"), level = DeprecationLevel.WARNING)
+fun <V : View> V.hideKeyboard() = hideKeyboard()
 
 /**
  * Waits until the view is measured until the function is invoked.

--- a/util-ui/src/main/kotlin/com/tailoredapps/androidutil/ui/keyboard/KeyboardExt.kt
+++ b/util-ui/src/main/kotlin/com/tailoredapps/androidutil/ui/keyboard/KeyboardExt.kt
@@ -4,6 +4,8 @@ import android.app.Activity
 import android.content.Context
 import android.view.View
 import android.view.inputmethod.InputMethodManager
+import androidx.appcompat.app.AppCompatActivity
+import io.reactivex.Observable
 
 /**
  * Created by alexandergrafl on 2019-11-05.
@@ -12,17 +14,20 @@ import android.view.inputmethod.InputMethodManager
 /**
  * Creates an instance of [KeyboardStateManager] and returns the [KeyboardStatus] Observable
  */
-fun <A: Activity> A.keyboardStates() = KeyboardStateManager(this).status()
+val <A : AppCompatActivity> A.keyboardStates: Observable<KeyboardStatus>
+        get() = KeyboardStateManager(this).status
 
 /**
- * Creates an instance of [KeyboardStateManager] and returns the current [KeyboardStatus] as Single
+ * Creates an instance of [KeyboardStateManager] and returns the current [KeyboardStatus]
  */
-fun <A: Activity> A.currentKeyboardStatus() = KeyboardStateManager(this).currentStatus()
+val <A : AppCompatActivity> A.currentKeyboardStatus: KeyboardStatus
+    get() = KeyboardStateManager(this).currentStatus
 
 /**
  * Creates an instance of [KeyboardStateManager] and returns whether the current [KeyboardStatus] is [KeyboardStatus.OPEN]
  */
-fun <A: Activity> A.isKeyboardOpen() = KeyboardStateManager(this).isKeyboardOpen()
+val <A : AppCompatActivity> A.isKeyboardOpen: Boolean
+    get() = KeyboardStateManager(this).isKeyboardOpen
 
 /**
  * Shows the keyboard for a view and focuses it.
@@ -37,7 +42,8 @@ fun <V : View> V.showKeyboard() {
  * Hides the keyboard for a view and unfocuses it.
  */
 fun <V : View> V.hideKeyboard() {
-    val inputMethodManager = context.getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
+    val inputMethodManager =
+        context.getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
     if (inputMethodManager.isActive) inputMethodManager.hideSoftInputFromWindow(windowToken, 0)
     clearFocus()
 }

--- a/util-ui/src/main/kotlin/com/tailoredapps/androidutil/ui/keyboard/KeyboardExt.kt
+++ b/util-ui/src/main/kotlin/com/tailoredapps/androidutil/ui/keyboard/KeyboardExt.kt
@@ -1,0 +1,43 @@
+package com.tailoredapps.androidutil.ui.keyboard
+
+import android.app.Activity
+import android.content.Context
+import android.view.View
+import android.view.inputmethod.InputMethodManager
+
+/**
+ * Created by alexandergrafl on 2019-11-05.
+ */
+
+/**
+ * Creates an instance of [KeyboardStateManager] and returns the [KeyboardStatus] Observable
+ */
+fun <A: Activity> A.keyboardStates() = KeyboardStateManager(this).status()
+
+/**
+ * Creates an instance of [KeyboardStateManager] and returns the current [KeyboardStatus] as Single
+ */
+fun <A: Activity> A.currentKeyboardStatus() = KeyboardStateManager(this).currentStatus()
+
+/**
+ * Creates an instance of [KeyboardStateManager] and returns whether the current [KeyboardStatus] is [KeyboardStatus.OPEN]
+ */
+fun <A: Activity> A.isKeyboardOpen() = KeyboardStateManager(this).isKeyboardOpen()
+
+/**
+ * Shows the keyboard for a view and focuses it.
+ */
+fun <V : View> V.showKeyboard() {
+    requestFocus()
+    val imm = context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+    imm.showSoftInput(this, InputMethodManager.SHOW_IMPLICIT)
+}
+
+/**
+ * Hides the keyboard for a view and unfocuses it.
+ */
+fun <V : View> V.hideKeyboard() {
+    val inputMethodManager = context.getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
+    if (inputMethodManager.isActive) inputMethodManager.hideSoftInputFromWindow(windowToken, 0)
+    clearFocus()
+}

--- a/util-ui/src/main/kotlin/com/tailoredapps/androidutil/ui/keyboard/KeyboardStateManager.kt
+++ b/util-ui/src/main/kotlin/com/tailoredapps/androidutil/ui/keyboard/KeyboardStateManager.kt
@@ -1,0 +1,62 @@
+package com.tailoredapps.androidutil.ui.keyboard
+
+import android.app.Activity
+import android.graphics.Rect
+import android.view.View
+import android.view.ViewTreeObserver
+import io.reactivex.Observable
+import io.reactivex.Single
+
+/**
+ * Created by alexandergrafl on 2019-11-05.
+ * Credit to https://medium.com/@munnsthoughts/detecting-if-the-android-keyboard-is-open-using-kotlin-rxjava-2-8aee9fae262c
+ * Manages access to the Android soft keyboard.
+ */
+class KeyboardStateManager(private val activity: Activity) {
+
+    /**
+     * Observable of the status of the keyboard. Subscribing to this creates a
+     * Global Layout Listener which is automatically removed when this
+     * observable is disposed.
+     */
+    fun status() = Observable.create<KeyboardStatus> { emitter ->
+        val rootView = activity.findViewById<View>(android.R.id.content)
+
+        // why are we using a global layout listener? Surely Android
+        // has callback for when the keyboard is open or closed? Surely
+        // Android at least lets you query the status of the keyboard?
+        // Nope! https://stackoverflow.com/questions/4745988/
+        val globalLayoutListener = ViewTreeObserver.OnGlobalLayoutListener {
+
+            val rect = Rect().apply { rootView.getWindowVisibleDisplayFrame(this) }
+
+            val screenHeight = rootView.height
+
+            // rect.bottom is the position above soft keypad or device button.
+            // if keypad is shown, the rect.bottom is smaller than that before.
+            val keypadHeight = screenHeight - rect.bottom
+
+            // 0.15 ratio is perhaps enough to determine keypad height.
+            if (keypadHeight > screenHeight * 0.15) {
+                emitter.onNext(KeyboardStatus.OPEN)
+            } else {
+                emitter.onNext(KeyboardStatus.CLOSED)
+            }
+        }
+
+        rootView.viewTreeObserver.addOnGlobalLayoutListener(globalLayoutListener)
+
+        emitter.setCancellable {
+            rootView.viewTreeObserver.removeOnGlobalLayoutListener(globalLayoutListener)
+        }
+
+    }.distinctUntilChanged()
+
+    fun currentStatus(): Single<KeyboardStatus> = status().share().singleOrError()
+
+    fun isKeyboardOpen(): Single<Boolean>  = currentStatus().map { it == KeyboardStatus.OPEN }
+}
+
+enum class KeyboardStatus {
+    OPEN, CLOSED
+}


### PR DESCRIPTION
Add keyboard status managment and extension functions.
Can be instantiated by injection or directly in activities.
Credit to https://medium.com/@munnsthoughts/detecting-if-the-android-keyboard-is-open-using-kotlin-rxjava-2-8aee9fae262c